### PR TITLE
Add KADOE API client

### DIFF
--- a/src/KeeperAtDateOfEvent/Auth/JwtAuthHttpClientDecorator.php
+++ b/src/KeeperAtDateOfEvent/Auth/JwtAuthHttpClientDecorator.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Auth;
+
+use Tizo\Dvla\KeeperAtDateOfEvent\Auth\ValueObject\JwtToken;
+use Tizo\Dvla\VehicleEnquiry\Client\HttpClient;
+use Tizo\Dvla\VehicleEnquiry\Client\Response;
+use Tizo\Dvla\VehicleEnquiry\Client\ValueObject\HttpMethod;
+use Psr\Http\Message\UriInterface;
+
+final class JwtAuthHttpClientDecorator implements HttpClient
+{
+    public function __construct(private readonly HttpClient $innerClient, private readonly JwtToken $token)
+    {
+    }
+
+    /**
+     * @param array<string|int, mixed>|null $data
+     * @param array<string, string|array<string>> $headers
+     */
+    public function request(UriInterface $uri, HttpMethod $method, ?array $data = null, array $headers = []): Response
+    {
+        return $this->innerClient->request(
+            $uri,
+            $method,
+            $data,
+            [
+                'Authorization' => 'Bearer ' . $this->token->toString(),
+                ...$headers,
+            ]
+        );
+    }
+}

--- a/src/KeeperAtDateOfEvent/Auth/ValueObject/JwtToken.php
+++ b/src/KeeperAtDateOfEvent/Auth/ValueObject/JwtToken.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Auth\ValueObject;
+
+use ParagonIE\HiddenString\HiddenString;
+
+final class JwtToken
+{
+    private function __construct(private readonly HiddenString $value)
+    {
+    }
+
+    public static function fromString(string $token): self
+    {
+        return new self(new HiddenString($token, true, true));
+    }
+
+    public function toString(): string
+    {
+        return $this->value->getString();
+    }
+}

--- a/src/KeeperAtDateOfEvent/Client.php
+++ b/src/KeeperAtDateOfEvent/Client.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent;
+
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\VehicleKeeperScope;
+use Tizo\Dvla\VehicleEnquiry\Client\HttpClient;
+use Psr\Http\Message\UriInterface;
+
+final class Client
+{
+    public function __construct(private readonly HttpClient $httpClient, private readonly UriInterface $uri)
+    {
+    }
+
+    public function vehicleKeeper(): VehicleKeeperScope
+    {
+        return new VehicleKeeperScope($this->httpClient, $this->uri);
+    }
+}

--- a/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/Request/VehicleKeeperRequest.php
+++ b/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/Request/VehicleKeeperRequest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\Request;
+
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\RegistrationNumber;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\ChassisVin;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\Date;
+use Tizo\Dvla\VehicleEnquiry\Client\PayloadRequest;
+use Tizo\Dvla\VehicleEnquiry\Client\ValueObject\HttpMethod;
+
+final class VehicleKeeperRequest implements PayloadRequest
+{
+    private function __construct(
+        private readonly string $enquirerId,
+        private readonly string $reasonCode,
+        private readonly Date $eventDate,
+        private readonly string $referenceNumber,
+        private readonly ?RegistrationNumber $registrationNumber,
+        private readonly ?ChassisVin $chassisVin,
+        private readonly ?string $linkProviderId,
+    ) {
+    }
+
+    public static function forRegistrationNumber(
+        RegistrationNumber $registrationNumber,
+        string $enquirerId,
+        string $reasonCode,
+        Date $eventDate,
+        string $referenceNumber,
+        ?string $linkProviderId = null
+    ): self {
+        return new self($enquirerId, $reasonCode, $eventDate, $referenceNumber, $registrationNumber, null, $linkProviderId);
+    }
+
+    public static function forChassisVin(
+        ChassisVin $vin,
+        string $enquirerId,
+        string $reasonCode,
+        Date $eventDate,
+        string $referenceNumber,
+        ?string $linkProviderId = null
+    ): self {
+        return new self($enquirerId, $reasonCode, $eventDate, $referenceNumber, null, $vin, $linkProviderId);
+    }
+
+    public function method(): HttpMethod
+    {
+        return HttpMethod::POST;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function payload(): array
+    {
+        $payload = [
+            'enquirerId' => $this->enquirerId,
+            'reasonCode' => $this->reasonCode,
+            'eventDate' => $this->eventDate->toString(),
+            'referenceNumber' => $this->referenceNumber,
+        ];
+
+        if ($this->registrationNumber !== null) {
+            $payload['registrationNumber'] = $this->registrationNumber->toString();
+        }
+        if ($this->chassisVin !== null) {
+            $payload['chassisVin'] = $this->chassisVin->toString();
+        }
+        if ($this->linkProviderId !== null) {
+            $payload['linkProviderId'] = $this->linkProviderId;
+        }
+
+        return $payload;
+    }
+}

--- a/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/Response/VehicleKeeperResponse.php
+++ b/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/Response/VehicleKeeperResponse.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\Response;
+
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\Address;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\Keeper;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\ChassisVin;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\RegistrationNumber;
+use Tizo\Dvla\VehicleEnquiry\Scope\VehiclesScope\ValueObject\TaxStatus;
+use Assert\Assert;
+
+final class VehicleKeeperResponse
+{
+    private ?RegistrationNumber $registrationNumber = null;
+    private ?ChassisVin $chassisVin = null;
+    private ?string $make = null;
+    private ?string $model = null;
+    private ?string $colour = null;
+    private ?string $secondaryColour = null;
+    private ?Keeper $keeper = null;
+    private ?string $message = null;
+    private ?TaxStatus $taxStatus = null;
+    private ?int $seatingCapacity = null;
+    private ?string $bodyType = null;
+    private ?string $taxClass = null;
+    private ?string $fleetNumber = null;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array<mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        Assert::that($data)->keyExists('keeper');
+
+        $self = new self();
+        if (isset($data['registrationNumber'])) {
+            $self->registrationNumber = RegistrationNumber::fromString($data['registrationNumber']);
+        }
+        if (isset($data['chassisVin'])) {
+            $self->chassisVin = ChassisVin::fromString($data['chassisVin']);
+        }
+        $self->make = $data['make'] ?? null;
+        $self->model = $data['model'] ?? null;
+        $self->colour = $data['colour'] ?? null;
+        $self->secondaryColour = $data['secondaryColour'] ?? null;
+        $self->message = $data['message'] ?? null;
+        $self->keeper = Keeper::fromArray($data['keeper']);
+        $self->taxStatus = isset($data['taxStatus']) ? TaxStatus::from($data['taxStatus']) : null;
+        $self->seatingCapacity = isset($data['seatingCapacity']) ? (int) $data['seatingCapacity'] : null;
+        $self->bodyType = $data['bodyType'] ?? null;
+        $self->taxClass = $data['taxClass'] ?? null;
+        $self->fleetNumber = $data['fleetNumber'] ?? null;
+
+        return $self;
+    }
+
+    public function registrationNumber(): ?RegistrationNumber { return $this->registrationNumber; }
+    public function chassisVin(): ?ChassisVin { return $this->chassisVin; }
+    public function make(): ?string { return $this->make; }
+    public function model(): ?string { return $this->model; }
+    public function colour(): ?string { return $this->colour; }
+    public function secondaryColour(): ?string { return $this->secondaryColour; }
+    public function keeper(): ?Keeper { return $this->keeper; }
+    public function message(): ?string { return $this->message; }
+    public function taxStatus(): ?TaxStatus { return $this->taxStatus; }
+    public function seatingCapacity(): ?int { return $this->seatingCapacity; }
+    public function bodyType(): ?string { return $this->bodyType; }
+    public function taxClass(): ?string { return $this->taxClass; }
+    public function fleetNumber(): ?string { return $this->fleetNumber; }
+}

--- a/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/Address.php
+++ b/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/Address.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject;
+
+final class Address
+{
+    private function __construct(
+        private readonly ?string $line1,
+        private readonly ?string $line2,
+        private readonly ?string $line3,
+        private readonly ?string $line4,
+        private readonly ?string $line5,
+        private readonly ?string $postcode,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['line1'] ?? null,
+            $data['line2'] ?? null,
+            $data['line3'] ?? null,
+            $data['line4'] ?? null,
+            $data['line5'] ?? null,
+            $data['postcode'] ?? null,
+        );
+    }
+
+    public function line1(): ?string { return $this->line1; }
+    public function line2(): ?string { return $this->line2; }
+    public function line3(): ?string { return $this->line3; }
+    public function line4(): ?string { return $this->line4; }
+    public function line5(): ?string { return $this->line5; }
+    public function postcode(): ?string { return $this->postcode; }
+}

--- a/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/ChassisVin.php
+++ b/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/ChassisVin.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject;
+
+use Assert\Assert;
+
+final class ChassisVin
+{
+    private function __construct(private readonly string $value)
+    {
+        Assert::that($this->value)->notEmpty('VIN should not be empty.');
+    }
+
+    public static function fromString(string $vin): self
+    {
+        return new self($vin);
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/Date.php
+++ b/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/Date.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject;
+
+use Assert\Assert;
+
+final class Date
+{
+    private function __construct(private readonly string $date)
+    {
+        Assert::that($this->date)
+            ->date('Y-m-d');
+    }
+
+    public static function fromString(string $date): self
+    {
+        return new self($date);
+    }
+
+    public function toDateTime(): \DateTimeImmutable
+    {
+        $date = new \DateTimeImmutable($this->date);
+
+        return $date->setTime(0, 0);
+    }
+
+    public function toString(): string
+    {
+        return $this->date;
+    }
+}

--- a/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/Keeper.php
+++ b/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/Keeper.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject;
+
+final class Keeper
+{
+    private function __construct(
+        private readonly ?string $title,
+        private readonly ?string $firstNames,
+        private readonly ?string $lastName,
+        private readonly ?string $companyName,
+        private readonly ?Address $address,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['title'] ?? null,
+            $data['firstNames'] ?? null,
+            $data['lastName'] ?? null,
+            $data['companyName'] ?? null,
+            isset($data['address']) ? Address::fromArray($data['address']) : null,
+        );
+    }
+
+    public function title(): ?string { return $this->title; }
+    public function firstNames(): ?string { return $this->firstNames; }
+    public function lastName(): ?string { return $this->lastName; }
+    public function companyName(): ?string { return $this->companyName; }
+    public function address(): ?Address { return $this->address; }
+}

--- a/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/RegistrationNumber.php
+++ b/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/RegistrationNumber.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\VehicleEnquiry\Scope\VehiclesScope\ValueObject;
+
+use Assert\Assert;
+
+final class RegistrationNumber
+{
+    private function __construct(private readonly string $value)
+    {
+        Assert::that($this->value)->notEmpty('Registration number should not be empty.');
+    }
+
+    public static function fromString(string $registrationNumber): self
+    {
+        return new self($registrationNumber);
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/VehicleKeeperScope.php
+++ b/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/VehicleKeeperScope.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope;
+
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\Request\VehicleKeeperRequest;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\Response\VehicleKeeperResponse;
+use Tizo\Dvla\VehicleEnquiry\Scope\Scope;
+
+final class VehicleKeeperScope extends Scope
+{
+    protected static function pathFragment(): string
+    {
+        return 'vehicle-keeper';
+    }
+
+    public function get(VehicleKeeperRequest $request): VehicleKeeperResponse
+    {
+        $responseData = $this->sendAndDecode($request);
+
+        return VehicleKeeperResponse::fromArray($responseData);
+    }
+}

--- a/tests/KeeperAtDateOfEvent/Functional/ClientTest.php
+++ b/tests/KeeperAtDateOfEvent/Functional/ClientTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Functional\Tizo\Dvla\KeeperAtDateOfEvent;
+
+use Tizo\Dvla\KeeperAtDateOfEvent\Auth\JwtAuthHttpClientDecorator;
+use Tizo\Dvla\KeeperAtDateOfEvent\Auth\ValueObject\JwtToken;
+use Tizo\Dvla\KeeperAtDateOfEvent\Client;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\Request\VehicleKeeperRequest;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\Date;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\RegistrationNumber;
+use Tizo\Dvla\VehicleEnquiry\Auth\ApiKeyAuthHttpClientDecorator;
+use Tizo\Dvla\VehicleEnquiry\Auth\ValueObject\ApiKey;
+use Tizo\Dvla\VehicleEnquiry\Psr18ClientDecorator;
+use Nyholm\Psr7\Request as Psr7Request;
+use Nyholm\Psr7\Response as Psr7Response;
+use Nyholm\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Client\ClientInterface;
+
+final class ClientTest extends TestCase
+{
+    private const BASE_URL = 'https://127.0.0.1:1234/kadoe/v1';
+
+    private ClientInterface&MockObject $httpClient;
+
+    private Client $fixture;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->httpClient = $this->createMock(ClientInterface::class);
+
+        $this->fixture = new Client(
+            new ApiKeyAuthHttpClientDecorator(
+                new JwtAuthHttpClientDecorator(
+                    new Psr18ClientDecorator(
+                        $this->httpClient
+                    ),
+                    JwtToken::fromString('jwt')
+                ),
+                ApiKey::fromString('apikey')
+            ),
+            new Uri(self::BASE_URL)
+        );
+    }
+
+    public function test_it_requests_vehicle_keeper_and_decodes_response(): void
+    {
+        $request = VehicleKeeperRequest::forRegistrationNumber(
+            RegistrationNumber::fromString('AA19AAA'),
+            'ENQ1',
+            '00EV',
+            Date::fromString('2023-04-01'),
+            'REF123'
+        );
+
+        $this->httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->willReturnCallback(
+                function (Psr7Request $req): Psr7Response {
+                    $this->assertSame(self::BASE_URL . '/vehicle-keeper', $req->getUri()->__toString());
+                    $this->assertSame('POST', $req->getMethod());
+                    $req->getBody()->rewind();
+                    $this->assertSame(
+                        '{"enquirerId":"ENQ1","reasonCode":"00EV","eventDate":"2023-04-01","referenceNumber":"REF123","registrationNumber":"AA19AAA"}',
+                        $req->getBody()->getContents()
+                    );
+
+                    return new Psr7Response(
+                        200,
+                        [],
+                        '{"registrationNumber":"AA19AAA","make":"Honda","model":"CR-V","taxStatus":"Untaxed","keeper":{"title":"MR","firstNames":"JOE","lastName":"BLOGGS","address":{"line1":"1 TEST","postcode":"TT1 1TT"}}}'
+                    );
+                }
+            );
+
+        $response = $this->fixture->vehicleKeeper()->get($request);
+
+        $this->assertSame('AA19AAA', $response->registrationNumber()?->toString());
+        $this->assertSame('Honda', $response->make());
+        $this->assertSame('CR-V', $response->model());
+    }
+}


### PR DESCRIPTION
## Summary
- implement Keeper At Date of Event (KADOE) client
- support JWT authentication
- add VehicleKeeper request/response logic
- test requesting a vehicle keeper

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685938a66ef48327b2d16a9ff9359201