### PR TITLE
Add KADOE usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,53 @@ which contains all the returned API response data in value objects.
 
 This example is using the UAT API URL and a test registration number. [Test registration numbers](https://developer-portal.driver-vehicle-licensing.api.gov.uk/apis/vehicle-enquiry-service/mock-responses.html#test-vrns)
 for mock responses of the different test cases are available in the [DVLA Vehicle Enquiry Service API documentation](https://developer-portal.driver-vehicle-licensing.api.gov.uk/apis/vehicle-enquiry-service/vehicle-enquiry-service-description.html#vehicle-enquiry-service-api).
+
+### Keeper at Date of Event example
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Tizo\Dvla\VehicleEnquiry\Auth\ApiKeyAuthHttpClientDecorator;
+use Tizo\Dvla\VehicleEnquiry\Auth\ValueObject\ApiKey;
+use Tizo\Dvla\VehicleEnquiry\Psr18ClientDecorator;
+use Tizo\Dvla\KeeperAtDateOfEvent\Auth\JwtTokenProvider;
+use Tizo\Dvla\KeeperAtDateOfEvent\Auth\RefreshingJwtAuthHttpClientDecorator;
+use Tizo\Dvla\KeeperAtDateOfEvent\Client as KadoeClient;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\Request\VehicleKeeperRequest;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\Date;
+use Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject\RegistrationNumber;
+use Nyholm\Psr7\Uri;
+
+$httpClient = new YourPsr18HttpClient();
+$psr18 = new Psr18ClientDecorator($httpClient);
+
+$tokenProvider = new JwtTokenProvider(
+    $psr18,
+    new Uri('https://uat.driver-vehicle-licensing.api.gov.uk/kadoe/v1'),
+    'YOUR-USERNAME',
+    'YOUR-PASSWORD'
+);
+
+$client = new KadoeClient(
+    new ApiKeyAuthHttpClientDecorator(
+        new RefreshingJwtAuthHttpClientDecorator(
+            $psr18,
+            $tokenProvider
+        ),
+        ApiKey::fromString('YOUR-API-KEY')
+    ),
+    new Uri('https://uat.driver-vehicle-licensing.api.gov.uk/kadoe/v1')
+);
+
+$keeperDetails = $client->vehicleKeeper()->get(
+    VehicleKeeperRequest::forRegistrationNumber(
+        RegistrationNumber::fromString('AA19AAA'),
+        'ENQ1',
+        '00EV',
+        Date::fromString('2023-04-01'),
+        'REF123'
+    )
+);
+```

--- a/src/KeeperAtDateOfEvent/Auth/JwtTokenProvider.php
+++ b/src/KeeperAtDateOfEvent/Auth/JwtTokenProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Auth;
+
+use DateTimeImmutable;
+use Tizo\Dvla\KeeperAtDateOfEvent\Auth\ValueObject\JwtToken;
+use Tizo\Dvla\VehicleEnquiry\Client\HttpClient;
+use Tizo\Dvla\VehicleEnquiry\Client\Response;
+use Tizo\Dvla\VehicleEnquiry\Client\ValueObject\HttpMethod;
+use Psr\Http\Message\UriInterface;
+
+final class JwtTokenProvider
+{
+    private ?JwtToken $token = null;
+
+    private ?DateTimeImmutable $expiresAt = null;
+
+    public function __construct(
+        private readonly HttpClient $httpClient,
+        private readonly UriInterface $baseUri,
+        private readonly string $username,
+        private readonly string $password,
+    ) {
+    }
+
+    public function token(): JwtToken
+    {
+        if ($this->token === null || $this->isExpired()) {
+            $this->authenticate();
+        }
+
+        return $this->token;
+    }
+
+    public function refresh(): JwtToken
+    {
+        $this->authenticate();
+
+        return $this->token;
+    }
+
+    private function isExpired(): bool
+    {
+        return $this->expiresAt === null || (new DateTimeImmutable()) >= $this->expiresAt;
+    }
+
+    private function authenticate(): void
+    {
+        $uri = $this->baseUri->withPath(
+            $this->baseUri->getPath() . '/thirdparty-access/v1/authenticate'
+        );
+
+        $response = $this->httpClient->request(
+            $uri,
+            HttpMethod::POST,
+            [
+                'username' => $this->username,
+                'password' => $this->password,
+            ]
+        );
+
+        $data = $response->content()->decode();
+        if (!isset($data['token']) || !isset($data['expires_in'])) {
+            throw new \RuntimeException('Invalid authentication response');
+        }
+
+        $this->token = JwtToken::fromString((string) $data['token']);
+        $this->expiresAt = (new DateTimeImmutable())
+            ->modify('+' . (int) $data['expires_in'] . ' seconds');
+    }
+}

--- a/src/KeeperAtDateOfEvent/Auth/RefreshingJwtAuthHttpClientDecorator.php
+++ b/src/KeeperAtDateOfEvent/Auth/RefreshingJwtAuthHttpClientDecorator.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Auth;
+
+use Tizo\Dvla\VehicleEnquiry\Client\HttpClient;
+use Tizo\Dvla\VehicleEnquiry\Client\Response;
+use Tizo\Dvla\VehicleEnquiry\Client\ValueObject\HttpMethod;
+use Psr\Http\Message\UriInterface;
+
+final class RefreshingJwtAuthHttpClientDecorator implements HttpClient
+{
+    public function __construct(
+        private readonly HttpClient $innerClient,
+        private readonly JwtTokenProvider $tokenProvider,
+    ) {
+    }
+
+    /**
+     * @param array<string|int, mixed>|null $data
+     * @param array<string, string|array<string>> $headers
+     */
+    public function request(UriInterface $uri, HttpMethod $method, ?array $data = null, array $headers = []): Response
+    {
+        $token = $this->tokenProvider->token();
+
+        return $this->innerClient->request(
+            $uri,
+            $method,
+            $data,
+            [
+                'Authorization' => 'Bearer ' . $token->toString(),
+                ...$headers,
+            ]
+        );
+    }
+}

--- a/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/RegistrationNumber.php
+++ b/src/KeeperAtDateOfEvent/Scope/VehicleKeeperScope/ValueObject/RegistrationNumber.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tizo\Dvla\VehicleEnquiry\Scope\VehiclesScope\ValueObject;
+namespace Tizo\Dvla\KeeperAtDateOfEvent\Scope\VehicleKeeperScope\ValueObject;
 
 use Assert\Assert;
 

--- a/tests/KeeperAtDateOfEvent/Unit/JwtTokenProviderTest.php
+++ b/tests/KeeperAtDateOfEvent/Unit/JwtTokenProviderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Tizo\Dvla\KeeperAtDateOfEvent;
+
+use Tizo\Dvla\KeeperAtDateOfEvent\Auth\JwtTokenProvider;
+use Tizo\Dvla\VehicleEnquiry\Client\HttpClient;
+use Tizo\Dvla\VehicleEnquiry\Client\Response;
+use Tizo\Dvla\VehicleEnquiry\Client\ValueObject\Content;
+use Tizo\Dvla\VehicleEnquiry\Client\ValueObject\HttpMethod;
+use Nyholm\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+final class JwtTokenProviderTest extends TestCase
+{
+    private HttpClient&MockObject $httpClient;
+    private JwtTokenProvider $fixture;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->httpClient = $this->createMock(HttpClient::class);
+        $this->fixture = new JwtTokenProvider(
+            $this->httpClient,
+            new Uri('https://example.com'),
+            'user',
+            'pass'
+        );
+    }
+
+    public function test_it_refreshes_when_token_is_expired(): void
+    {
+        $this->httpClient->expects($this->exactly(2))
+            ->method('request')
+            ->with(
+                $this->callback(fn($uri) => (string) $uri === 'https://example.com/thirdparty-access/v1/authenticate'),
+                HttpMethod::POST,
+                ['username' => 'user', 'password' => 'pass']
+            )
+            ->willReturnOnConsecutiveCalls(
+                Response::with(200, [], Content::fromString('{"token":"first","expires_in":0}')),
+                Response::with(200, [], Content::fromString('{"token":"second","expires_in":60}'))
+            );
+
+        $first = $this->fixture->token();
+        $second = $this->fixture->token();
+
+        $this->assertSame('first', $first->toString());
+        $this->assertSame('second', $second->toString());
+    }
+}

--- a/tests/KeeperAtDateOfEvent/Unit/RefreshingJwtAuthHttpClientDecoratorTest.php
+++ b/tests/KeeperAtDateOfEvent/Unit/RefreshingJwtAuthHttpClientDecoratorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Tizo\Dvla\KeeperAtDateOfEvent;
+
+use Tizo\Dvla\KeeperAtDateOfEvent\Auth\RefreshingJwtAuthHttpClientDecorator;
+use Tizo\Dvla\KeeperAtDateOfEvent\Auth\JwtTokenProvider;
+use Tizo\Dvla\VehicleEnquiry\Client\HttpClient;
+use Tizo\Dvla\VehicleEnquiry\Client\Response;
+use Tizo\Dvla\VehicleEnquiry\Client\ValueObject\Content;
+use Tizo\Dvla\VehicleEnquiry\Client\ValueObject\HttpMethod;
+use Nyholm\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\UriInterface;
+
+final class RefreshingJwtAuthHttpClientDecoratorTest extends TestCase
+{
+    private HttpClient&MockObject $innerClient;
+    private RefreshingJwtAuthHttpClientDecorator $fixture;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->innerClient = $this->createMock(HttpClient::class);
+
+        $providerHttp = new class() implements HttpClient {
+            public int $call = 0;
+
+            public function request(UriInterface $uri, HttpMethod $method, ?array $data = null, array $headers = []): Response
+            {
+                $this->call++;
+                $token = $this->call === 1 ? 'first' : 'second';
+
+                return Response::with(200, [], Content::fromString('{"token":"' . $token . '","expires_in":0}'));
+            }
+        };
+
+        $provider = new JwtTokenProvider(
+            $providerHttp,
+            new Uri('https://example.com'),
+            'user',
+            'pass'
+        );
+
+        $this->fixture = new RefreshingJwtAuthHttpClientDecorator(
+            $this->innerClient,
+            $provider
+        );
+    }
+
+    public function test_it_fetches_the_token_before_every_request(): void
+    {
+        $call = 0;
+        $this->innerClient->expects($this->exactly(2))
+            ->method('request')
+            ->willReturnCallback(
+                function (UriInterface $uri, HttpMethod $method, ?array $data, array $headers) use (&$call): Response {
+                    $call++;
+                    $expected = $call === 1 ? 'first' : 'second';
+                    $this->assertSame('Bearer ' . $expected, $headers['Authorization']);
+
+                    return Response::with(200, [], Content::empty());
+                }
+            );
+
+        $uri = new Uri('https://example.com/test');
+
+        $this->fixture->request($uri, HttpMethod::GET);
+        $this->fixture->request($uri, HttpMethod::GET);
+    }
+}


### PR DESCRIPTION
## Summary
- document how to call Keeper at Date of Event API using new JWT token provider and refreshing decorator

## Testing
- `composer test:unit` *(fails: composer not installed)*